### PR TITLE
Fix navigation button to show profile overview

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,7 +20,7 @@
 
   <!-- === NAVIGATION (Teil 1) === -->
   <nav id="mainNav"><!-- Hauptnavigation -->
-    <button onclick="showPage('profiles')">🔍 Profile</button><!-- Profilansicht -->
+    <button onclick="showPage('profileOverview')">🔍 Profile</button><!-- Profilansicht -->
     <button onclick="showPage('groups')">👪 Gruppen</button><!-- Gruppenansicht -->
     <button onclick="showPage('tree')">🌳 Stammbaum</button><!-- Baumansicht -->
     <button onclick="showPage('settings')">⚙️ Einstellungen</button><!-- Einstellungen -->


### PR DESCRIPTION
## Summary
- correct the Profile navigation button to display the existing `profileOverview` section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68646bb07f8c832487a1b8fab5f338ee