### PR TITLE
Fix profile fetch endpoint

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -101,7 +101,7 @@ document.getElementById("joinGroupForm").addEventListener("submit", async e => {
 });
 // === Block 5: Profile aus API anzeigen ===
 async function loadProfiles() {
-  const res = await fetch(`${API_BASE}/api/groups`);
+  const res = await fetch(`${API_BASE}/api/persons`);
   const data = await res.json();
   const list = document.getElementById("profileList");
   list.innerHTML = "";


### PR DESCRIPTION
## Summary
- fix the fetch URL in `loadProfiles()` to request `/api/persons`

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686482227e0c8324a04d9ccb4581d3e1