### PR TITLE
Defer profile loading until join

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -67,7 +67,9 @@ function showPage(sectionId) {
   } else if (sectionId === "settings") {
     loadSettings();
   } else if (sectionId === "profileOverview") {
-    loadProfiles();
+    if (currentGroupId || window.genealogyData) {
+      loadProfiles();
+    }
   }
 }
 
@@ -134,14 +136,19 @@ document.getElementById("joinGroupForm").addEventListener("submit", async e => {
 // === Block 5: Profile aus API anzeigen ===
 async function loadProfiles() {
   try {
-    const res = await fetch(`${API_BASE}/api/persons`);
-    if (!res.ok) throw new Error();
-    const data = await res.json();
+    let data;
+    if (window.genealogyData) {
+      data = window.genealogyData;
+    } else {
+      const res = await fetch(`${API_BASE}/api/persons`);
+      if (!res.ok) throw new Error();
+      data = await res.json();
+    }
     const list = document.getElementById("profileList");
     list.innerHTML = "";
     data.forEach(p => {
       const li = document.createElement("li");
-      li.textContent = `${p.name} (${p.birthYear})`;
+      li.textContent = `${p.name} (${p.birthYear || ""})`;
       li.addEventListener("click", () => showProfile(p));
       list.appendChild(li);
     });
@@ -352,5 +359,7 @@ document.getElementById("onlyMembers").addEventListener("change", saveSettings);
 // === Block 8: Initialer Aufruf nach Laden der Seite ===
 window.addEventListener("DOMContentLoaded", () => {
   loadGroups();
-  loadProfiles();
+  if (window.genealogyData) {
+    loadProfiles();
+  }
 });


### PR DESCRIPTION
## Summary
- load profiles only if a group is joined or the demo dataset is present
- trigger initial profile load only when using demo dataset
- support demo dataset in `loadProfiles`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6865cc7e95dc8324bfa780d334b1b5e4