### PR TITLE
Add basic relationship tests

### DIFF
--- a/js/family.js
+++ b/js/family.js
@@ -1,0 +1,24 @@
+function linkFamily(persons) {
+  const byId = {};
+  persons.forEach(p => {
+    byId[p.id] = p;
+    p.children = p.children ? p.children.slice() : [];
+    p.parents = p.parents ? p.parents.slice() : [];
+  });
+
+  // Replace children id lists with object references
+  persons.forEach(p => {
+    p.childObjs = p.children.map(cid => byId[cid]).filter(Boolean);
+  });
+
+  // Build parent links as object references
+  persons.forEach(p => {
+    p.parentObjs = p.parents.map(pid => byId[pid]).filter(Boolean);
+  });
+
+  return persons;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = { linkFamily };
+}

--- a/js/tests/relationshipTest.js
+++ b/js/tests/relationshipTest.js
@@ -1,0 +1,19 @@
+const { linkFamily } = require('../family');
+
+// Construct simple family
+const persons = [
+  { id: 1, name: 'Parent', children: [2] },
+  { id: 2, name: 'Child', parents: [1], children: [3] },
+  { id: 3, name: 'Grandchild', parents: [2] }
+];
+
+linkFamily(persons);
+
+const byId = Object.fromEntries(persons.map(p => [p.id, p]));
+
+console.assert(byId[1].childObjs[0] === byId[2], 'Parent should link to child');
+console.assert(byId[2].parentObjs[0] === byId[1], 'Child should link to parent');
+console.assert(byId[2].childObjs[0] === byId[3], 'Child should link to grandchild');
+console.assert(byId[3].parentObjs[0] === byId[2], 'Grandchild should link to parent');
+
+console.log('All tests passed.');

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Family platform frontend",
   "scripts": {
-    "test": "echo \"No tests specified\" && exit 0"
+    "test": "node js/tests/relationshipTest.js"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- add `linkFamily` helper to build parent/child object links
- create simple console-assert tests
- run tests via `npm test`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6866f3f311a88324919cc401ce9d1a74