### PR TITLE
Implement full tree view with partners

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -211,6 +211,10 @@ section form input[type="url"] {
   height: 2px;
   background: #aaa;
 }
+.partnerGroup > div {
+  display: flex;
+  gap: 6px;
+}
 .selected {
   background-color: #fffbcc;      /* Markierung */
   font-weight: bold;

--- a/index.html
+++ b/index.html
@@ -101,5 +101,6 @@
   <!-- === Ende Body & Einbindung App-Script === -->
   <script src="js/familyData.js"></script><!-- Beispiel-Daten -->
   <script src="js/app.js"></script><!-- JavaScript-Logik -->
+  <script src="js/treeBuilder.js"></script><!-- Baumdarstellung -->
 </body>
 </html>

--- a/js/app.js
+++ b/js/app.js
@@ -397,6 +397,11 @@ async function exportProfiles() {
   }
 }
 
+// Zeigt den kompletten Baum mit Partnern an
+function renderTreeView() {
+  buildFullTree(personMap, 'treeContainer');
+}
+
 // === Block 8.1: Stammbaum anzeigen ===
 async function loadTree() {
   const container = document.getElementById("treeContainer");
@@ -431,6 +436,10 @@ async function loadTree() {
   });
   // globale Referenzen setzen
   byId = personMap;
+
+  // Neue Darstellungsfunktion für die vollständige Baumansicht
+  renderTreeView();
+  return;
 
   // Helper: build nested list items recursively
   function buildNode(person) {
@@ -510,12 +519,19 @@ function computeRelation(personId) {
     personId = select.value;
   }
 
+  document
+    .querySelectorAll("#treeContainer .selected")
+    .forEach(el => el.classList.remove("selected"));
+
   if (!personId || !byId[personId]) {
     info.textContent = "";
     return;
   }
 
   const person = byId[personId];
+
+  const selEl = document.querySelector(`#treeContainer [data-id='${personId}']`);
+  if (selEl) selEl.classList.add("selected");
 
   const resolveNames = ids =>
     (ids || [])

--- a/js/familyData.js
+++ b/js/familyData.js
@@ -2,47 +2,47 @@
 // Each object represents a person with numeric id
 window.genealogyData = [
   // 1. Stammvater
-  { id: 1, name: "Francois", children: [2, 3, 4, 5, 6, 7, 8, 9] },
+  { id: 1, name: "Francois", spouse: 42, children: [2, 3, 4, 5, 6, 7, 8, 9] },
 
   // Kinder von Francois
-  { id: 2, name: "Elvire", parents: [1], children: [10, 11, 12] },
-  { id: 3, name: "Sandra", parents: [1], children: [13, 14, 15] },
-  { id: 4, name: "Vivien", parents: [1], children: [16, 17] },
-  { id: 5, name: "Thierry", parents: [1], children: [18, 19] },
-  { id: 6, name: "Stephanie", parents: [1], children: [20, 21] },
-  { id: 7, name: "Zephirin", parents: [1], children: [22, 23, 24, 25, 26, 27] },
-  { id: 8, name: "Alain", parents: [1], children: [28, 29] },
-  { id: 9, name: "Judith", parents: [1], children: [30, 31, 32, 33, 34, 35] },
+  { id: 2, name: "Elvire", spouse: 36, parents: [1, 42], children: [10, 11, 12] },
+  { id: 3, name: "Sandra", spouse: 37, parents: [1, 42], children: [13, 14, 15] },
+  { id: 4, name: "Vivien", spouse: 38, parents: [1, 42], children: [16, 17] },
+  { id: 5, name: "Thierry", spouses: [39, 40], parents: [1, 42], children: [18, 19] },
+  { id: 6, name: "Stephanie", spouse: 41, parents: [1, 42], children: [20, 21] },
+  { id: 7, name: "Zephirin", spouse: 43, parents: [1, 42], children: [22, 23, 24, 25, 26, 27] },
+  { id: 8, name: "Alain", parents: [1, 42], children: [28, 29] },
+  { id: 9, name: "Judith", parents: [1, 42], children: [30, 31, 32, 33, 34, 35] },
 
   // Kinder von Elvire
-  { id: 10, name: "Ghais", parents: [2] },
-  { id: 11, name: "Julianna", parents: [2] },
-  { id: 12, name: "Djessie", parents: [2] },
+  { id: 10, name: "Ghais", parents: [2, 36] },
+  { id: 11, name: "Julianna", parents: [2, 36] },
+  { id: 12, name: "Djessie", parents: [2, 36] },
 
   // Kinder von Sandra
-  { id: 13, name: "Maeli", parents: [3] },
-  { id: 14, name: "Francois", parents: [3] },
-  { id: 15, name: "Dila", parents: [3] },
+  { id: 13, name: "Maeli", parents: [3, 37] },
+  { id: 14, name: "Francois", parents: [3, 37] },
+  { id: 15, name: "Dila", parents: [3, 37] },
 
   // Kinder von Vivien
-  { id: 16, name: "Ophelie", parents: [4] },
-  { id: 17, name: "Lyam", parents: [4] },
+  { id: 16, name: "Ophelie", parents: [4, 38] },
+  { id: 17, name: "Lyam", parents: [4, 38] },
 
   // Kinder von Thierry
-  { id: 18, name: "Nael", parents: [5] },
-  { id: 19, name: "Nayla", parents: [5] },
+  { id: 18, name: "Nael", parents: [5, 39] },
+  { id: 19, name: "Nayla", parents: [5, 40] },
 
   // Kinder von Stephanie
-  { id: 20, name: "Gabriel", parents: [6] },
-  { id: 21, name: "Owen", parents: [6] },
+  { id: 20, name: "Gabriel", parents: [6, 41] },
+  { id: 21, name: "Owen", parents: [6, 41] },
 
   // Kinder von Zephirin
-  { id: 22, name: "Chloe", parents: [7] },
-  { id: 23, name: "Erika", parents: [7] },
-  { id: 24, name: "Milenne", parents: [7] },
-  { id: 25, name: "Joyce", parents: [7] },
-  { id: 26, name: "Nobel", parents: [7] },
-  { id: 27, name: "Ange", parents: [7] },
+  { id: 22, name: "Chloe", parents: [7, 43] },
+  { id: 23, name: "Erika", parents: [7, 43] },
+  { id: 24, name: "Milenne", parents: [7, 43] },
+  { id: 25, name: "Joyce", parents: [7, 43] },
+  { id: 26, name: "Nobel", parents: [7, 43] },
+  { id: 27, name: "Ange", parents: [7, 43] },
 
   // Kinder von Alain
   { id: 28, name: "Première fille", parents: [8] },
@@ -54,5 +54,15 @@ window.genealogyData = [
   { id: 32, name: "Troisième", parents: [9] },
   { id: 33, name: "Fille unique", parents: [9] },
   { id: 34, name: "Fille unique 1", parents: [9] },
-  { id: 35, name: "Fille??", parents: [9] }
+  { id: 35, name: "Fille??", parents: [9] },
+
+  // Partner und Partnerinnen
+  { id: 36, name: "Armand", spouse: 2, children: [10, 11, 12] },
+  { id: 37, name: "Simon", spouse: 3, children: [13, 14, 15] },
+  { id: 38, name: "Vanessa", spouse: 4, children: [16, 17] },
+  { id: 39, name: "Mari", spouse: 5, children: [18] },
+  { id: 40, name: "Patricia", spouse: 5, children: [19] },
+  { id: 41, name: "Narcisse", spouse: 6, children: [20, 21] },
+  { id: 42, name: "Nono Odette", spouse: 1, children: [2, 3, 4, 5, 6, 7, 8, 9] },
+  { id: 43, name: "Natou", spouse: 7, children: [22, 23, 24, 25, 26, 27] }
 ];

--- a/js/treeBuilder.js
+++ b/js/treeBuilder.js
@@ -1,0 +1,114 @@
+function buildFullTree(personMap, containerId) {
+  const container = document.getElementById(containerId);
+  if (!container) return;
+  container.innerHTML = "";
+
+  const processedPairs = new Set();
+
+  const persons = Object.values(personMap);
+  const roots = persons.filter(p => {
+    if (p.parents && p.parents.length) return false;
+    const spouseIds = Array.isArray(p.spouses)
+      ? p.spouses
+      : p.spouse
+      ? [p.spouse]
+      : [];
+    if (spouseIds.length) {
+      const min = Math.min(p.id, ...spouseIds);
+      return p.id === min;
+    }
+    return true;
+  });
+
+  const tree = document.createElement("ul");
+  roots.forEach(r => {
+    const node = buildSubtree(r);
+    if (node) tree.appendChild(node);
+  });
+  container.appendChild(tree);
+
+  function getSpouseIds(p) {
+    return Array.isArray(p.spouses) ? p.spouses : p.spouse ? [p.spouse] : [];
+  }
+
+  function makeLabel(p) {
+    const span = document.createElement("span");
+    span.dataset.id = p.id;
+    span.textContent = `${p.name}${p.birthYear ? ` (${p.birthYear})` : ""}`;
+    span.addEventListener("click", () => {
+      const sel = document.getElementById("treeSelect");
+      if (sel) sel.value = p.id;
+      computeRelation(p.id);
+    });
+    return span;
+  }
+
+  function buildSubtree(person) {
+    const spouseIds = getSpouseIds(person);
+    if (spouseIds.length > 1) {
+      const frag = document.createDocumentFragment();
+      spouseIds.forEach(id => {
+        const key = [person.id, id].sort().join("-");
+        if (!processedPairs.has(key)) {
+          processedPairs.add(key);
+          const li = buildCouple(person, personMap[id]);
+          if (li) frag.appendChild(li);
+        }
+      });
+      return frag;
+    }
+    if (spouseIds.length === 1) {
+      const key = [person.id, spouseIds[0]].sort().join("-");
+      if (processedPairs.has(key)) return null;
+      processedPairs.add(key);
+      return buildCouple(person, personMap[spouseIds[0]]);
+    }
+    return buildSingle(person);
+  }
+
+  function collectSharedChildren(p1, p2) {
+    if (!p2) return p1.children || [];
+    return (p1.children || []).filter(c => (p2.children || []).includes(c));
+  }
+
+  function buildCouple(p1, p2) {
+    const li = document.createElement("li");
+    li.classList.add("partnerGroup");
+    const head = document.createElement("div");
+    head.appendChild(makeLabel(p1));
+    if (p2) head.appendChild(makeLabel(p2));
+    li.appendChild(head);
+
+    const childIds = collectSharedChildren(p1, p2);
+    if (childIds.length) {
+      const ul = document.createElement("ul");
+      childIds.forEach(cid => {
+        const child = personMap[cid];
+        if (child) {
+          const n = buildSubtree(child);
+          if (n) ul.appendChild(n);
+        }
+      });
+      li.appendChild(ul);
+    }
+    return li;
+  }
+
+  function buildSingle(p) {
+    const li = document.createElement("li");
+    li.appendChild(makeLabel(p));
+    const kids = p.children || [];
+    if (kids.length) {
+      const ul = document.createElement("ul");
+      kids.forEach(cid => {
+        const ch = personMap[cid];
+        if (ch) {
+          const n = buildSubtree(ch);
+          if (n) ul.appendChild(n);
+        }
+      });
+      li.appendChild(ul);
+    }
+    return li;
+  }
+}


### PR DESCRIPTION
## Summary
- support couples and spouses in example data
- highlight selected tree entries and render combined partner nodes
- visualize family tree with new `buildFullTree` helper
- include `treeBuilder.js` and styling for partner groups

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686863e8b4fc83249d252f9c0a8a227c